### PR TITLE
Enable cloud-init

### DIFF
--- a/scripts/ubuntu/cleanup.sh
+++ b/scripts/ubuntu/cleanup.sh
@@ -61,3 +61,9 @@ df -h
 
 echo '==> Clearing Ubuntu machine-id'
 sudo cp /dev/null /etc/machine-id
+
+echo '==> Resetting networking'
+rm -f /etc/netplan/*.yaml \
+    /etc/cloud/cloud.cfg.d/99-installer.cfg \
+    /etc/cloud/cloud.cfg.d/subiquity-disable-cloudinit-networking.cfg
+cloud-init clean --seed --logs

--- a/scripts/ubuntu/update.sh
+++ b/scripts/ubuntu/update.sh
@@ -26,7 +26,7 @@ if [[ $UPDATE  =~ true || $UPDATE =~ 1 || $UPDATE =~ yes ]]; then
     apt -y autoremove --purge
 fi
 apt -y install build-essential linux-headers-generic
-apt -y install ssh nfs-common vim curl perl git
+apt -y install ssh nfs-common vim curl perl git cloud-init
 apt -y autoclean
 apt -y clean
 


### PR DESCRIPTION
This patch enables cloud-init in the VM.

Without it, the VM has hard-coded networking (dhcp on interface `enp3s0`).  This is problematic in environments where the network interface is called something else - e.g. `ens3`, which is what qemu provides.  Cloud-init also permits users to provide a cloud-init data source to configure networking and/or change user/pass details at startup.

However, when there is no cloud-init data source, cloud-init will just configure the external interface with dhcp4 anyway: e.g.

```
$ cat /etc/netplan/50-cloud-init.yaml 
# This file is generated from information provided by the datasource.  Changes
# to it will not persist across an instance reboot.  To disable cloud-init's
# network configuration capabilities, write a file
# /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg with the following:
# network: {config: disabled}
network:
    ethernets:
        ens3:
            dhcp4: true
            match:
                macaddress: 0c:e6:24:f7:04:00
            set-name: ens3
    version: 2
```

~~(for ease of testing, I based this on top of #26. I can rebase onto master if you prefer)~~ Now rebased, and fixed reset of cloud-init state