### PR TITLE
Move zeroing of disk space to end of disk build

### DIFF
--- a/scripts/ubuntu/cleanup.sh
+++ b/scripts/ubuntu/cleanup.sh
@@ -48,11 +48,6 @@ if [ "x${swapuuid}" != "x" ]; then
     /sbin/mkswap -U "${swapuuid}" "${swappart}"
 fi
 
-# Zero out the free space to save space in the final image
-dd if=/dev/zero of=/EMPTY bs=1M  || echo "dd exit code $? is suppressed"
-rm -f /EMPTY
-sync
-
 echo "==> Disk usage before cleanup"
 echo ${DISK_USAGE_BEFORE_CLEANUP}
 

--- a/scripts/ubuntu/minimize.sh
+++ b/scripts/ubuntu/minimize.sh
@@ -47,5 +47,10 @@ rm -rf /usr/share/doc/*
 echo "==> Removing caches"
 find /var/cache -type f -exec rm -rf {} \;
 
+# Zero out the free space to save space in the final image
+dd if=/dev/zero of=/EMPTY bs=1M  || echo "dd exit code $? is suppressed"
+rm -f /EMPTY
+sync
+
 echo "==> Disk usage after cleanup"
 df -h


### PR DESCRIPTION
The step which zeros out unused disk space currently happens quite early:

* "scripts/ubuntu/cleanup.sh",  << here
* "scripts/common/finish.sh",
* "scripts/ubuntu/minimize.sh",
* "scripts/common/clean_users.sh"

This patch moves it to the end of `minimize.sh`, so that disk space freed by `apt-get -y autoremove --purge` etc actually shrinks the image.

~~(For simplicity this was applied on top of #27, but I can rebase if required)~~ Now rebased